### PR TITLE
Fixes #1 by using `self.as_mut_ptr()`

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -25,7 +25,7 @@ impl<T: Ord> BlitSort<T> for [T] {
                 }
             }
             blitsort(
-                self.as_ptr() as *mut c_void,
+                self.as_mut_ptr() as *mut c_void,
                 self.len(),
                 size_of::<T>(),
                 Some(cmp::<T>),


### PR DESCRIPTION
Fixes #1 by using `self.as_mut_ptr()` instead of `self.as_ptr()` to allow write access across the FFI. 
